### PR TITLE
Create Checkpppoe.sh

### DIFF
--- a/Checkpppoe.sh
+++ b/Checkpppoe.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+    getgw() {
+		gw=$(ifconfig pppoe-${1} | grep inet | awk '{print $3}' | cut -c 7-)
+		echo $gw
+    }
+
+
+	erri=0
+	while true
+	do
+		gw=$(getgw $1)
+		echo "Ping----${gw}-------"
+		ping -c 1 -W 1 $gw > /dev/null
+		if [ $? -eq 0 ];then
+			echo 'ok'
+			sleep 2
+		else
+			erri=$(( $erri + 1 ))
+			echo "Ping ateway error ${erri} times..."
+			sleep 1
+		fi
+		
+		if [ $erri -ge 3 ];then
+			echo "Gateway missing......re-dial.."
+			erri=0
+			ifdown ${1} && ifup ${1}
+			sleep 15
+		fi	
+	done
+


### PR DESCRIPTION
电信pppoe被踢不能自动重连监测脚本
ping监测对象为 p-t-p的ip   线路正常或者没被踢这个ip不会不通的 
开机启动脚本里添加 Checkpppoe.sh wan
多拨就加多个  Checkpppoe.sh wan1 Checkpppoe.sh wan2......